### PR TITLE
Update for Sketch 45

### DIFF
--- a/Relabel Button.sketchplugin/Contents/Sketch/Relabel Button Right Aligned.js
+++ b/Relabel Button.sketchplugin/Contents/Sketch/Relabel Button Right Aligned.js
@@ -13,8 +13,8 @@
 var relabelButtonRightAligned = function(context) {
   // set doc and selection to work around the Sketch 3.4 - 3.4.2 bug 
   // where plugins often target a non-foreground document 
-  var doc = NSDocumentController.sharedDocumentController().currentDocument() || NSDocumentController.sharedDocumentController().documents().firstObject()
-  var selection = doc ? doc.findSelectedLayers() : nil
+  var doc = context.document;
+  var selection = context.selection;
 
   // Begin validation of selection
   // Ensure there's only one layer selected

--- a/Relabel Button.sketchplugin/Contents/Sketch/Relabel Button.js
+++ b/Relabel Button.sketchplugin/Contents/Sketch/Relabel Button.js
@@ -13,8 +13,8 @@
 var relabelButton = function(context) {
   // set doc and selection to work around the Sketch 3.4 - 3.4.2 bug 
   // where plugins often target a non-foreground document 
-  var doc = NSDocumentController.sharedDocumentController().currentDocument() || NSDocumentController.sharedDocumentController().documents().firstObject()
-  var selection = doc ? doc.findSelectedLayers() : nil
+  var doc = context.document;
+  var selection = context.selection;
 
   // Begin validation of selection
   // Ensure there's only one layer selected


### PR DESCRIPTION
This should actually support earlier versions of Sketch (back to 41 or even earlier?). Accessing the document and selection has been vastly simplified in recent versions of Sketch.